### PR TITLE
feat: persist username in localStorage across sessions

### DIFF
--- a/guess_movie/lyrizz/templates/lyrizz/room.html
+++ b/guess_movie/lyrizz/templates/lyrizz/room.html
@@ -23,6 +23,12 @@ setTimeout(() => {
     $('#start-link').removeClass('disabled');
 }, 2000);
 
+var savedUsername = localStorage.getItem('movizz_username');
+if (savedUsername && /^Anonymous[A-Za-z0-9]{6}$/.test($("#user-name").val())) {
+  $("#user-name").val(savedUsername);
+  $.ajax({ url: '/lyrizz/change_user_name/', data: { 'user_name': savedUsername }, dataType: 'json' });
+}
+
 /*
 var webSocketFactory = {
   connectionTries: 1,
@@ -199,9 +205,8 @@ $("#user-name").keyup(function(){
               },
               dataType: 'json',
               success: function (data) {
-                context = {'user_name': user_name}
-                userSocket.send(JSON.stringify(context));
-
+                if (user_name.trim()) localStorage.setItem('movizz_username', user_name);
+                userSocket.send(JSON.stringify({'user_name': user_name}));
               }
           });
 

--- a/guess_movie/quizz/templates/quizz/room.html
+++ b/guess_movie/quizz/templates/quizz/room.html
@@ -21,6 +21,12 @@ ALREADY_CREATED = 0
 
 setTimeout(() => { $('#start-link').removeClass('disabled'); }, 2000);
 
+var savedUsername = localStorage.getItem('movizz_username');
+if (savedUsername && /^Anonymous[A-Za-z0-9]{6}$/.test($('#user-name').val())) {
+  $('#user-name').val(savedUsername);
+  $.ajax({ url: '/change_user_name/', data: { 'user_name': savedUsername }, dataType: 'json' });
+}
+
 // ── WebSocket helpers ──────────────────────────────────────────────────
 connect_socket = function(url) {
   var connectionTries = 1;
@@ -139,6 +145,7 @@ $('#user-name').keyup(function() {
       data: { 'user_name': user_name },
       dataType: 'json',
       success: function(data) {
+        if (user_name.trim()) localStorage.setItem('movizz_username', user_name);
         userSocket.send(JSON.stringify({'user_name': user_name}));
       }
     });


### PR DESCRIPTION
When a user sets a custom nickname in the lobby, it is saved to localStorage under the key 'movizz_username'. On the next visit, if the Django session has expired and a fresh Anonymous*** name was assigned, the saved nickname is silently restored and the session is updated via the existing change_user_name endpoint.

Applies to both Movizz and Lyrizz lobbies. No backend changes needed.